### PR TITLE
Unregister databus in store at activity pause

### DIFF
--- a/app/src/main/java/com/armueller/fluxytodo/models/TodoListManager.java
+++ b/app/src/main/java/com/armueller/fluxytodo/models/TodoListManager.java
@@ -20,6 +20,7 @@ public class TodoListManager {
     private final HashMap<Long, TodoItem> backupTodoItems;
     private final HashMap<Long, TodoItem> todoItems;
     private final DataBus dataBus;
+    private final ActionBus actionBus;
 
     @Inject
     public TodoListManager(ActionBus actionBus, DataBus dataBus) {
@@ -27,7 +28,13 @@ public class TodoListManager {
         todoItems = new HashMap<Long, TodoItem>();
         this.dataBus = dataBus;
         dataBus.register(this);
+        this.actionBus = actionBus;
         actionBus.register(this);
+    }
+
+    public void onPause() {
+        dataBus.unregister(this);
+        actionBus.unregister(this);
     }
 
     @Subscribe

--- a/app/src/main/java/com/armueller/fluxytodo/stores/TodosActivityStore.java
+++ b/app/src/main/java/com/armueller/fluxytodo/stores/TodosActivityStore.java
@@ -20,6 +20,7 @@ public class TodosActivityStore {
     private Boolean shouldShowUndoButton;
 
     private DataBus dataBus;
+    private ActionBus actionBus;
     private RawTodoList rawTodoList;
     private FilteredTodoList.Filter activeFilter;
 
@@ -27,12 +28,17 @@ public class TodosActivityStore {
     public TodosActivityStore(ActionBus actionBus, DataBus dataBus) {
         this.dataBus = dataBus;
         dataBus.register(this);
+        this.actionBus = actionBus;
         actionBus.register(this);
         editModeActiveForTodoId = new Long(-1);
         shouldShowUndoButton = Boolean.FALSE;
-
         activeFilter = FilteredTodoList.Filter.ALL;
         rawTodoList = new RawTodoList();
+    }
+
+    public void onPause() {
+        dataBus.unregister(this);
+        actionBus.unregister(this);
     }
 
     @Subscribe

--- a/app/src/main/java/com/armueller/fluxytodo/views/todos/TodosActivity.java
+++ b/app/src/main/java/com/armueller/fluxytodo/views/todos/TodosActivity.java
@@ -104,12 +104,13 @@ public class TodosActivity extends Activity {
 
     @Override
     protected void onResume() {
-        super.onPause();
+        super.onResume();
         dataBus.register(this);
     }
 
     @Override
     protected void onPause() {
+        todosActivityStore.onPause();
         super.onPause();
         dataBus.unregister(this);
     }

--- a/app/src/main/java/com/armueller/fluxytodo/views/todos/fragment/TodosFragment.java
+++ b/app/src/main/java/com/armueller/fluxytodo/views/todos/fragment/TodosFragment.java
@@ -120,8 +120,9 @@ public class TodosFragment extends Fragment {
 
     @Override
     public void onPause() {
-        super.onPause();
+        todoListManager.onPause();
         dataBus.unregister(this);
+        super.onPause();
     }
 
     @Override


### PR DESCRIPTION
TodoListManager and TodosActivityStore were registred to DataBus,
but since they were created in the context of the Activity they
should have unregistred in onPause to avoid an exeption in the
following onResume when going back/from the application.

Currently all tasks are lost in this case, so next thing to fix
would be to save data (persistently) in the application context
and restore it to the activity when the app is resumed.
